### PR TITLE
chore: add --expected-size to fix prod backups

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -52,7 +52,7 @@ pg_dump_database() {
 upload_to_bucket() {
     # if the zipped backup file is larger than 50 GB add the --expected-size option
     # see https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
-    s3 cp - "s3://$S3_BUCKET_NAME/$(date +%Y/%m/%d/backup-%H-%M-%S.sql.gz)"
+    s3 cp --expected-size=120GB - "s3://$S3_BUCKET_NAME/$(date +%Y/%m/%d/backup-%H-%M-%S.sql.gz)"
 }
 
 main() {


### PR DESCRIPTION
Prod backups have become large enough that the `s3 cp` command fails (over 77GB).  Adding an expected size of 120GB should get the backups working again and give us some breathing room to put together a more permanent solution.